### PR TITLE
Set timeout to None for CA as it fixes the gateway issue linked in #5

### DIFF
--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -58,7 +58,12 @@ class CAUpdateHandler:
         (self._pv,) = context.get_pvs(
             pv_name, connection_state_callback=self._connection_state_callback
         )
+
+        # This is needed for the case when the PV doesn't exist before it has been added
+        # ie. if a gateway has not yet been configured.
+        # None means no timeout - it will eventually connect. 
         self._pv.timeout = None
+        
         # Subscribe with "data_type='time'" to get timestamp and alarm fields
         sub = self._pv.subscribe(data_type="time")
         sub.add_callback(self._monitor_callback)


### PR DESCRIPTION
## Issue

Closes #5 

## Description of work

This sets the connection timeout (as per https://caproto.github.io/caproto/v1.2.0/threading-client.html#caproto.threading.client.PV.timeout) to None (or infinite) as we were hitting an issue where if a PV isn't available after the forwarder has received a config update it never reconnects. 


## Checklist

- [ ] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
