### PR TITLE
Can now use KAFKA_BROKER global config variable

### DIFF
--- a/forwarder_launch.bat
+++ b/forwarder_launch.bat
@@ -13,4 +13,5 @@ set "EPICS_CA_ADDR_LIST=127.255.255.255 130.246.55.255"
 set "EPICS_CA_AUTO_ADDR_LIST=NO"
 
 echo "starting forwarder"
-python %~dp0forwarder_launch.py --status-topic=%BROKER%/%INSTRUMENT%_forwarderStatus --config-topic=%KAFKA_BROKER%/%INSTRUMENT%_forwarderConfig --storage-topic=%KAFKA_BROKER%/%INSTRUMENT%_forwarderStorage  --output-broker=%KAFKA_BROKER%
+python %~dp0forwarder_launch.py --status-topic=%KAFKA_BROKER%/%INSTRUMENT%_forwarderStatus --config-topic=%KAFKA_BROKER%/%INSTRUMENT%_forwarderConfig --storage-topic=%KAFKA_BROKER%/%INSTRUMENT%_forwarderStorage  --output-broker=%KAFKA_BROKER%
+

--- a/forwarder_launch.bat
+++ b/forwarder_launch.bat
@@ -1,13 +1,16 @@
-call C:\Instrument\Apps\EPICS\isis\forwarder\master\.venv\scripts\activate
+setlocal
+call %~dp0..\..\..\config_env_base.bat
+@echo on
+set "GETMACRO=%EPICS_KIT_ROOT%\support\icpconfig\master\bin\%EPICS_HOST_ARCH%\icpconfigGetMacro.exe"
+set "MYIOCNAME=FORWARDER"
+set "KAFKA_BROKER=livedata.isis.cclrc.ac.uk:31092"
+REM allow local config override in globals.txt
+for /f %%a in ( '%GETMACRO% "KAFKA_BROKER" %MYIOCNAME%'  ) do ( set "KAFKA_BROKER=%%a" )
+
+call %~dp0.venv\scripts\activate
 
 set "EPICS_CA_ADDR_LIST=127.255.255.255 130.246.55.255"
 set "EPICS_CA_AUTO_ADDR_LIST=NO"
 
-if "%INSTRUMENT%" == "HIFI" (
-    set "BROKER=130.246.55.29:9092"
-) else (
-    set "BROKER=livedata.isis.cclrc.ac.uk:31092"
-)
-
 echo "starting forwarder"
-python C:\Instrument\Apps\EPICS\isis\forwarder\master\forwarder_launch.py --status-topic=%BROKER%/%INSTRUMENT%_forwarderStatus --config-topic=%BROKER%/%INSTRUMENT%_forwarderConfig --storage-topic=%BROKER%/%INSTRUMENT%_forwarderStorage  --output-broker=%BROKER%
+python %~dp0forwarder_launch.py --status-topic=%BROKER%/%INSTRUMENT%_forwarderStatus --config-topic=%KAFKA_BROKER%/%INSTRUMENT%_forwarderConfig --storage-topic=%KAFKA_BROKER%/%INSTRUMENT%_forwarderStorage  --output-broker=%KAFKA_BROKER%


### PR DESCRIPTION
## Description of work

*Allow use of BROKER_CONFIG in globals.txt 

## Checklist

- [ ] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
